### PR TITLE
[syseepromd] support new platform api with plugin mode compatible

### DIFF
--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -59,7 +59,7 @@ class DaemonSyseeprom(DaemonBase):
     def load_platform_api(self):
         try:
             self.eeprom = DaemonBase.load_chassis(self).get_eeprom()
-            return self.eeprom is None
+            return self.eeprom is not None
         except Exception as e:
             logger.log_warning("Failed to load chassis due to {}".format(repr(e)))
             return False

--- a/sonic-syseepromd/scripts/syseepromd
+++ b/sonic-syseepromd/scripts/syseepromd
@@ -43,7 +43,8 @@ class DaemonSyseeprom(DaemonBase):
 
         self.stop_event = threading.Event()
         self.eeprom_util = None
-        
+        self.eeprom = None
+
         state_db = daemon_base.db_connect(swsscommon.STATE_DB)
         self.eeprom_tbl = swsscommon.Table(state_db, EEPROM_TABLE_NAME)
         self.eepromtbl_keys = []
@@ -55,19 +56,45 @@ class DaemonSyseeprom(DaemonBase):
             logger.log_error("Failed to load eeprom utility: %s" % (str(e)), True)
             sys.exit(ERR_EEPROMUTIL_LOAD)
 
+    def load_platform_api(self):
+        try:
+            self.eeprom = DaemonBase.load_chassis(self).get_eeprom()
+            return self.eeprom is None
+        except Exception as e:
+            logger.log_warning("Failed to load chassis due to {}".format(repr(e)))
+            return False
+
+    def _wrapper_read_eeprom(self):
+        if self.eeprom is not None:
+            try:
+                return self.eeprom.read_eeprom()
+            except NotImplementedError:
+                pass
+
+        return self.eeprom_util.read_eeprom()
+
+    def _wrapper_update_eeprom_db(self, eeprom):
+        if self.eeprom is not None:
+            try:
+                return self.eeprom.update_eeprom_db(eeprom)
+            except NotImplementedError:
+                pass
+
+        return self.eeprom_util.update_eeprom_db(eeprom)
+
     def post_eeprom_to_db(self):
-        eeprom = self.eeprom_util.read_eeprom()
+        eeprom = self._wrapper_read_eeprom()
         if eeprom is None :
             logger.log_error("Failed to read eeprom")
             return ERR_FAILED_EEPROM
 
-        err = self.eeprom_util.update_eeprom_db(eeprom)
+        err = self._wrapper_update_eeprom_db(eeprom)
         if err:
             logger.log_error("Failed to update eeprom info to database")
             return ERR_FAILED_UPDATE_DB
 
         self.eepromtbl_keys = self.eeprom_tbl.getKeys()
-        
+
         return POST_EEPROM_SUCCESS
 
     def clear_db(self):
@@ -104,8 +131,11 @@ class DaemonSyseeprom(DaemonBase):
     def run(self):
         logger.log_info("Starting up...")
 
-        # Load platform-specific eepromutil class
-        self.load_eeprom_util()
+        # with new platform api supported, we should try loading it first
+        if not self.load_platform_api():
+            # Load platform-specific eepromutil class
+            # in case of loading new platform api failed
+            self.load_eeprom_util()
 
         # Connect to STATE_DB and post syseeprom info to state DB
         rc = self.post_eeprom_to_db()


### PR DESCRIPTION
Support new platform api with plugin mode compatible.
In this PR, new platform api is supported in following steps:
1. initialization, load new-platform-api-based class eeprom, if failed then load old style plugin.
2. for each api, call new platform api, old style plugin is called if the former raised a NotImplementError; other Exceptions raised will be passed to caller without handling.

now only two apis are in syseepromd, update_eeprom_db and read_eeprom