### PR TITLE
[psud] Bug fix: the fields that are not supported by vendor should be "N/A" in STATE_DB

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -310,7 +310,7 @@ class PsuStatus(object):
         return True
 
     def set_voltage(self, voltage, high_threshold, low_threshold):
-        if not voltage or not high_threshold or not low_threshold:
+        if voltage == NOT_AVAILABLE or high_threshold == NOT_AVAILABLE or low_threshold == NOT_AVAILABLE:
             if self.voltage_good is not True:
                 self.logger.log_warning('PSU voltage or high_threshold or low_threshold become unavailable, '
                                         'voltage={}, high_threshold={}, low_threshold={}'.format(voltage, high_threshold, low_threshold))
@@ -325,7 +325,7 @@ class PsuStatus(object):
         return True
 
     def set_temperature(self, temperature, high_threshold):
-        if not temperature or not high_threshold:
+        if temperature == NOT_AVAILABLE or high_threshold == NOT_AVAILABLE:
             if self.temperature_good is not True:
                 self.logger.log_warning('PSU temperature or high_threshold become unavailable, '
                                         'temperature={}, high_threshold={}'.format(temperature, high_threshold))
@@ -443,23 +443,23 @@ class DaemonPsud(daemon_base.DaemonBase):
         name = get_psu_key(index)
         presence = _wrapper_get_psu_presence(index)
         power_good = False
-        voltage = None
-        voltage_high_threshold = None
-        voltage_low_threshold = None
-        temperature = None
-        temperature_threshold = None
-        current = None
-        power = None
+        voltage = NOT_AVAILABLE
+        voltage_high_threshold = NOT_AVAILABLE
+        voltage_low_threshold = NOT_AVAILABLE
+        temperature = NOT_AVAILABLE
+        temperature_threshold = NOT_AVAILABLE
+        current = NOT_AVAILABLE
+        power = NOT_AVAILABLE
         is_replaceable = try_get(psu.is_replaceable, False)
         if presence:
             power_good = _wrapper_get_psu_status(index)
-            voltage = try_get(psu.get_voltage)
-            voltage_high_threshold = try_get(psu.get_voltage_high_threshold)
-            voltage_low_threshold = try_get(psu.get_voltage_low_threshold)
-            temperature = try_get(psu.get_temperature)
-            temperature_threshold = try_get(psu.get_temperature_high_threshold)
-            current = try_get(psu.get_current)
-            power = try_get(psu.get_power)
+            voltage = try_get(psu.get_voltage, NOT_AVAILABLE)
+            voltage_high_threshold = try_get(psu.get_voltage_high_threshold, NOT_AVAILABLE)
+            voltage_low_threshold = try_get(psu.get_voltage_low_threshold, NOT_AVAILABLE)
+            temperature = try_get(psu.get_temperature, NOT_AVAILABLE)
+            temperature_threshold = try_get(psu.get_temperature_high_threshold, NOT_AVAILABLE)
+            current = try_get(psu.get_current, NOT_AVAILABLE)
+            power = try_get(psu.get_power, NOT_AVAILABLE)
 
         if index not in self.psu_status_dict:
             self.psu_status_dict[index] = PsuStatus(self, psu)
@@ -506,8 +506,8 @@ class DaemonPsud(daemon_base.DaemonBase):
             self._set_psu_led(psu, psu_status)
 
         fvs = swsscommon.FieldValuePairs(
-            [(PSU_INFO_MODEL_FIELD, str(try_get(psu.get_model))),
-             (PSU_INFO_SERIAL_FIELD, str(try_get(psu.get_serial))),
+            [(PSU_INFO_MODEL_FIELD, str(try_get(psu.get_model, NOT_AVAILABLE))),
+             (PSU_INFO_SERIAL_FIELD, str(try_get(psu.get_serial, NOT_AVAILABLE))),
              (PSU_INFO_TEMP_FIELD, str(temperature)),
              (PSU_INFO_TEMP_TH_FIELD, str(temperature_threshold)),
              (PSU_INFO_VOLTAGE_FIELD, str(voltage)),

--- a/sonic-psud/tests/test_PsuStatus.py
+++ b/sonic-psud/tests/test_PsuStatus.py
@@ -117,27 +117,27 @@ class TestPsuStatus(object):
         assert psu_status.voltage_good == True
 
         # Test passing parameters as None when voltage_good == True
-        ret = psu_status.set_voltage(None, 12.5, 11.5)
+        ret = psu_status.set_voltage(psud.NOT_AVAILABLE, 12.5, 11.5)
         assert ret == False
         assert psu_status.voltage_good == True
-        ret = psu_status.set_voltage(11.5, None, 11.5)
+        ret = psu_status.set_voltage(11.5, psud.NOT_AVAILABLE, 11.5)
         assert ret == False
         assert psu_status.voltage_good == True
-        ret = psu_status.set_voltage(11.5, 12.5, None)
+        ret = psu_status.set_voltage(11.5, 12.5, psud.NOT_AVAILABLE)
         assert ret == False
         assert psu_status.voltage_good == True
 
         # Test passing parameters as None when voltage_good == False
         psu_status.voltage_good = False
-        ret = psu_status.set_voltage(None, 12.5, 11.5)
+        ret = psu_status.set_voltage(psud.NOT_AVAILABLE, 12.5, 11.5)
         assert ret == False
         assert psu_status.voltage_good == True
         psu_status.voltage_good = False
-        ret = psu_status.set_voltage(11.5, None, 11.5)
+        ret = psu_status.set_voltage(11.5, psud.NOT_AVAILABLE, 11.5)
         assert ret == False
         assert psu_status.voltage_good == True
         psu_status.voltage_good = False
-        ret = psu_status.set_voltage(11.5, 12.5, None)
+        ret = psu_status.set_voltage(11.5, 12.5, psud.NOT_AVAILABLE)
         assert ret == False
         assert psu_status.voltage_good == True
 
@@ -174,20 +174,20 @@ class TestPsuStatus(object):
         assert psu_status.temperature_good == True
 
         # Test passing parameters as None when temperature_good == True
-        ret = psu_status.set_temperature(None, 50.0)
+        ret = psu_status.set_temperature(psud.NOT_AVAILABLE, 50.0)
         assert ret == False
         assert psu_status.temperature_good == True
-        ret = psu_status.set_temperature(20.123, None)
+        ret = psu_status.set_temperature(20.123, psud.NOT_AVAILABLE)
         assert ret == False
         assert psu_status.temperature_good == True
 
         # Test passing parameters as None when temperature_good == False
         psu_status.temperature_good = False
-        ret = psu_status.set_temperature(None, 50.0)
+        ret = psu_status.set_temperature(psud.NOT_AVAILABLE, 50.0)
         assert ret == False
         assert psu_status.temperature_good == True
         psu_status.temperature_good = False
-        ret = psu_status.set_temperature(20.123, None)
+        ret = psu_status.set_temperature(20.123, psud.NOT_AVAILABLE)
         assert ret == False
         assert psu_status.temperature_good == True
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Bug fix: the fields that are not supported by vendor should be "N/A" in STATE_DB

- Initialize fields as "N/A" and set the field to "N/A" for those not supported by vendor API
- Update set_voltage, set_temperature, treating "N/A" instead of None as invalid values
- Update unit test cases accordingly

Signed-off-by: Stephen Sun <stephens@nvidia.com>

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manually test and regression test

#### Additional Information (Optional)
