### PR TITLE
WR for issue caused by copying FDs during fork

### DIFF
--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -722,7 +722,7 @@ class ThermalMonitor(ProcessTaskBase):
 
         self.chassis = chassis
 
-    def init_tables(self):
+    def init_updaters(self):
         self.fan_updater = FanUpdater(self.chassis, self.task_stopping_event)
         self.temperature_updater = TemperatureUpdater(self.chassis, self.task_stopping_event)
 
@@ -745,7 +745,7 @@ class ThermalMonitor(ProcessTaskBase):
         Thread function to handle Fan status update and temperature status update
         :return:
         """
-        self.init_tables()
+        self.init_updaters()
         self.logger.log_info("Start thermal monitoring loop")
 
         # Start loop to update fan, temperature info in DB periodically
@@ -755,24 +755,6 @@ class ThermalMonitor(ProcessTaskBase):
         self.temperature_updater.deinit()
 
         self.logger.log_info("Stop thermal monitoring loop")
-
-    def signal_handler(self, sig, frame):
-        """
-        Signal handler
-        :param sig: Signal number
-        :param frame: not used
-        :return:
-        """
-        FATAL_SIGNALS = [signal.SIGINT, signal.SIGTERM]
-        NONFATAL_SIGNALS = [signal.SIGHUP]
-
-        if sig in FATAL_SIGNALS:
-            self.log_info("Thermal monitor Caught signal '{}' - exiting...".format(SIGNALS_TO_NAMES_DICT[sig]))
-            self.task_stopping_event.set()
-        elif sig in NONFATAL_SIGNALS:
-            self.log_info("Caught signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
-        else:
-            self.log_warning("Caught unhandled signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
 
 #
 # Daemon =======================================================================
@@ -802,7 +784,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.thermal_monitor = ThermalMonitor(self.chassis)
         self.thermal_monitor.task_run()
-        self.thermal_monitor.init_tables()
+        self.thermal_monitor.init_updaters()
 
         self.thermal_manager = None
         try:

--- a/sonic-thermalctld/scripts/thermalctld
+++ b/sonic-thermalctld/scripts/thermalctld
@@ -720,8 +720,11 @@ class ThermalMonitor(ProcessTaskBase):
         # Set minimum logging level to INFO
         self.logger.set_min_log_priority_info()
 
-        self.fan_updater = FanUpdater(chassis, self.task_stopping_event)
-        self.temperature_updater = TemperatureUpdater(chassis, self.task_stopping_event)
+        self.chassis = chassis
+
+    def init_tables(self):
+        self.fan_updater = FanUpdater(self.chassis, self.task_stopping_event)
+        self.temperature_updater = TemperatureUpdater(self.chassis, self.task_stopping_event)
 
     def main(self):
         begin = time.time()
@@ -742,6 +745,7 @@ class ThermalMonitor(ProcessTaskBase):
         Thread function to handle Fan status update and temperature status update
         :return:
         """
+        self.init_tables()
         self.logger.log_info("Start thermal monitoring loop")
 
         # Start loop to update fan, temperature info in DB periodically
@@ -752,6 +756,23 @@ class ThermalMonitor(ProcessTaskBase):
 
         self.logger.log_info("Stop thermal monitoring loop")
 
+    def signal_handler(self, sig, frame):
+        """
+        Signal handler
+        :param sig: Signal number
+        :param frame: not used
+        :return:
+        """
+        FATAL_SIGNALS = [signal.SIGINT, signal.SIGTERM]
+        NONFATAL_SIGNALS = [signal.SIGHUP]
+
+        if sig in FATAL_SIGNALS:
+            self.log_info("Thermal monitor Caught signal '{}' - exiting...".format(SIGNALS_TO_NAMES_DICT[sig]))
+            self.task_stopping_event.set()
+        elif sig in NONFATAL_SIGNALS:
+            self.log_info("Caught signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
+        else:
+            self.log_warning("Caught unhandled signal '{}' - ignoring...".format(SIGNALS_TO_NAMES_DICT[sig]))
 
 #
 # Daemon =======================================================================
@@ -781,6 +802,7 @@ class ThermalControlDaemon(daemon_base.DaemonBase):
 
         self.thermal_monitor = ThermalMonitor(self.chassis)
         self.thermal_monitor.task_run()
+        self.thermal_monitor.init_tables()
 
         self.thermal_manager = None
         try:

--- a/sonic-thermalctld/tests/test_thermalctld.py
+++ b/sonic-thermalctld/tests/test_thermalctld.py
@@ -296,6 +296,7 @@ class TestThermalMonitor(object):
     def test_main(self):
         mock_chassis = MockChassis()
         thermal_monitor = thermalctld.ThermalMonitor(mock_chassis)
+        thermal_monitor.init_updaters()
         thermal_monitor.fan_updater.update = mock.MagicMock()
         thermal_monitor.temperature_updater.update = mock.MagicMock()
 


### PR DESCRIPTION
This is for discussion.
This is a WA for an issue caused by forking child.
Current logic:
1. thermal control starts, initializing thermal monitor object
2. db connections, which are based on socket, are created by fan/thermal updater during constructor of thermal monitor
3. task_run called for thermal monitor, which forks a new process.
   in this step, the sockets are duplicated and shared between the parent and child process
5. child runs, communicating with redis server via socket, during which time parent keeps silent
6. daemons receives SIG_TERM, child and parent exits.
   when parent does the cleaning up, redis server somehow sends some data which should be sent to client to server, disrupting parent's context. hence the error occurs

WA:
create db connections in parent/child process independently to avoid sharing sockets between them.
so far the issue doesn't reproduced.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
